### PR TITLE
Fix 'hidden' expand/collapse all buttons, increase CSS specificity

### DIFF
--- a/src/ilw-accordion.styles.css
+++ b/src/ilw-accordion.styles.css
@@ -42,6 +42,10 @@ ul.buttons {
     padding: 0;
 }
 
+ul.buttons[hidden] {
+    display: none;
+}
+
 ul.buttons li button {
     background-color: var(--ilw-accordion--button-background-color);
     border: 2px solid var(--ilw-accordion--button-border-color);


### PR DESCRIPTION
On the latest version of the component, I noticed that the expand/collapse all buttons were displayed even when the 'hidden' attribute is present on the `<ul>` element:

```HTML
<ul class="buttons" hidden>
    <li><button>Expand All</button></li>
    <li><button>Collapse All</button></li>
</ul>
```
Example on builder site: https://builder3.toolkit.illinois.edu/preview/ilw-accordion/1-1/index.html (Preview: default and buttons =)

I think the intent is to have the buttons be hidden by default, via that hidden attribute. But the attribute style is being overridden by a `display: flex` style for `ul.buttons` in the components stylesheet. I added a more specific style to that stylesheet; not sure if that's the best way to fix this, but it does seem to work. 